### PR TITLE
chore: update gitignore and clean up repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+**/.DS_Store
+
+# Claude Code configuration
+.claude/

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "rollup-plugin-visualizer": "^6.0.3",
     "typescript": "^5.5.0"
   },
-  "description": "Astro View Transitions実験プロジェクト",
+  "description": "Astro 実験プロジェクト",
   "volta": {
     "node": "22.5.0"
   }


### PR DESCRIPTION
## 概要
リポジトリのクリーンアップと.gitignoreの更新

## 変更内容
- `.claude/` ディレクトリを.gitignoreに追加（Claude Code設定ファイルの除外）
- `**/.DS_Store` パターンを追加（macOSシステムファイルの完全除外）
- package.jsonのdescriptionを簡略化
- .DS_Storeファイルをリポジトリから削除

## 理由
パブリックリポジトリとして不要な設定ファイルやシステムファイルを除外

## チェックリスト
- [x] .gitignoreの更新
- [x] 不要ファイルの削除
- [x] Conventional Commits準拠